### PR TITLE
Betterify property access, implement ES5 getters and ES6 syntax for objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,5 @@ node_js:
   - "iojs"
   - "4"
   - "5.1"
+
+script: make test-all

--- a/doc/basics-reference.markdown
+++ b/doc/basics-reference.markdown
@@ -156,7 +156,6 @@ generate arbitrary JavaScript are built in to eslisp.
 | `regex`    | regular expression literal   |
 | `var`      | variable declaration         |
 | `.`        | member expression            |
-| `get`      | *computed* member expression |
 | `switch`   | switch statement             |
 | `if`       | conditional statement        |
 | `?:`       | ternary expression           |
@@ -291,13 +290,13 @@ elements.
     ];
 
 Object literals are created with the `object` macro which expects its
-parameters to be alternating keys and values.
+parameters to be simple pairs keys and values.
 
 <!-- !test in object macro -->
 
     (object)
-    (object a 1)
-    (object "a" 1 "b" 2)
+    (object (:a 1))
+    (object ("a" 1) ("b" 2))
 
 <!-- !test out object macro -->
 
@@ -308,13 +307,63 @@ parameters to be alternating keys and values.
         'b': 2
     });
 
+ES5 getters and setters can be used.
+
+<!-- !test in object getter setter -->
+
+    (var data 0)
+    (object
+        (get :data () (return data))
+        (set :data (value) (= data value)))
+
+<!-- !test out object getter setter -->
+
+    var data = 0;
+    ({
+        get data() {
+            return data;
+        },
+        set data(value) {
+            data = value;
+        }
+    });
+
+ES6 methods, property shorthand, computed properties, etc. can be used. Computed
+properties can even be used with getters. Generators have not yet been
+implemented, though, so generator methods are not available.
+
+<!-- !test in object es6 -->
+
+    (var prop 2)
+    (var data (Symbol "data"))
+    (object
+        (:prop)
+        ((. Symbol :toStringTag) "foo")
+        (:method (arg) (return (+ arg 1)))
+        (get data () (return 1)))
+
+<!-- !test out object es6 -->
+
+    var prop = 2;
+    var data = Symbol('data');
+    ({
+        prop,
+        [Symbol.toStringTag]: 'foo',
+        method(arg) {
+            return arg + 1;
+        },
+        get [data]() {
+            return 1;
+        }
+    });
+
 Property access uses the `.` macro.
 
 <!-- !test in property access macro -->
 
     (. a 1)
-    (. a b (. c d))
-    (. a 1 "b" c)
+    (. a :b (. c :d))
+    (. a 1 "b" :c)
 
 <!-- !test out property access macro -->
 
@@ -325,13 +374,13 @@ Property access uses the `.` macro.
 If you wish you could just write those as `a.b.c` in eslisp code, use the
 [*eslisp-propertify*][10] user-macro.
 
-For *computed* property access, use the `get` macro.
+For *computed* property access, omit the leading colon.
 
 <!-- !test in computed property access macro -->
 
-    (get a b)
-    (get a b c 1)
-    (= (get a b) 5)
+    (. a b)
+    (. a b c 1)
+    (= (. a b) 5)
 
 <!-- !test out computed property access macro -->
 
@@ -398,9 +447,9 @@ the `default`-case clause.
 <!-- !test in switch statement -->
 
     (switch x
-        (1 ((. console log) "it is 1")
+        (1 ((. console :log) "it is 1")
            (break))
-        (default ((. console log) "it is not 1")))
+        (default ((. console :log) "it is not 1")))
 
 <!-- !test out switch statement -->
 
@@ -499,7 +548,7 @@ header, the second to be the right, and the rest to be body statements.
 <!-- !test in for-in loop -->
 
     (forin (var x) xs
-           ((. console log) (get xs x)))
+           ((. console :log) (. xs x)))
 
 <!-- !test out for-in loop -->
 
@@ -566,7 +615,7 @@ or `finally`, in which case they are treated as the catch- or finally-clause.
          (catch err
                 (logError err)
                 (f a b))
-         (finally ((. console log) "done")))
+         (finally ((. console :log) "done")))
 
 <!-- !test out try-catch -->
 

--- a/doc/basics-reference.markdown
+++ b/doc/basics-reference.markdown
@@ -295,7 +295,7 @@ parameters to be simple pairs keys and values.
 <!-- !test in object macro -->
 
     (object)
-    (object (:a 1))
+    (object ('a 1))
     (object ("a" 1) ("b" 2))
 
 <!-- !test out object macro -->
@@ -313,8 +313,8 @@ ES5 getters and setters can be used.
 
     (var data 0)
     (object
-        (get :data () (return data))
-        (set :data (value) (= data value)))
+        (get 'data () (return data))
+        (set 'data (value) (= data value)))
 
 <!-- !test out object getter setter -->
 
@@ -337,9 +337,9 @@ implemented, though, so generator methods are not available.
     (var prop 2)
     (var data (Symbol "data"))
     (object
-        (:prop)
-        ((. Symbol :toStringTag) "foo")
-        (:method (arg) (return (+ arg 1)))
+        ('prop)
+        ((. Symbol 'toStringTag) "foo")
+        ('method (arg) (return (+ arg 1)))
         (get data () (return 1)))
 
 <!-- !test out object es6 -->
@@ -362,8 +362,8 @@ Property access uses the `.` macro.
 <!-- !test in property access macro -->
 
     (. a 1)
-    (. a :b (. c :d))
-    (. a 1 "b" :c)
+    (. a 'b (. c 'd))
+    (. a 1 "b" 'c)
 
 <!-- !test out property access macro -->
 
@@ -447,9 +447,9 @@ the `default`-case clause.
 <!-- !test in switch statement -->
 
     (switch x
-        (1 ((. console :log) "it is 1")
+        (1 ((. console 'log) "it is 1")
            (break))
-        (default ((. console :log) "it is not 1")))
+        (default ((. console 'log) "it is not 1")))
 
 <!-- !test out switch statement -->
 
@@ -548,7 +548,7 @@ header, the second to be the right, and the rest to be body statements.
 <!-- !test in for-in loop -->
 
     (forin (var x) xs
-           ((. console :log) (. xs x)))
+           ((. console 'log) (. xs x)))
 
 <!-- !test out for-in loop -->
 
@@ -615,7 +615,7 @@ or `finally`, in which case they are treated as the catch- or finally-clause.
          (catch err
                 (logError err)
                 (f a b))
-         (finally ((. console :log) "done")))
+         (finally ((. console 'log) "done")))
 
 <!-- !test out try-catch -->
 

--- a/doc/how-macros-work.markdown
+++ b/doc/how-macros-work.markdown
@@ -55,12 +55,12 @@ Yey!
 
 We could of course have written the macro function in eslisp instead:
 
-    (= (. module :exports)
+    (= (. module 'exports)
        (lambda (name)
-        (return ((. this :list)
-                 ((. this :atom) "=")
+        (return ((. this 'list)
+                 ((. this 'atom) "=")
                  name
-                 ((. this :string) "hello")))))
+                 ((. this 'string) "hello")))))
 
 That compiles to the same JS before.  In fact, you can write macros in any
 language you want, as long as you can compile it to JS before `require`-ing it
@@ -74,12 +74,12 @@ syntax for *quoting*, which makes macro return values much easier to read:
 To make macros clearer to read, eslisp has special syntax for returning stuff
 that represents code.  Let's rewrite the previous hello-assigning macro:
 
-    (= (. module :exports) (lambda (name) (return `(var ,name "hello"))))
+    (= (. module 'exports) (lambda (name) (return `(var ,name "hello"))))
 
 That does exactly the same thing, but it contains less of the
 `atom`/`list`/`string` constructor fluff, so it's clearer to read.  The `(.
 this list)` constructor is replaced with a `` ` `` (backtick).  The `var` atom
-no longer needs to be written explicitly as `((. this :atom) var)` and there's
+no longer needs to be written explicitly as `((. this 'atom) var)` and there's
 now a `,` (comma) before `name`.
 
 In various other Lisp family languages that eslisp is inspired by, the backtick
@@ -117,13 +117,13 @@ expression necessary to calculate the mean of some variables, you could do
      (lambda ()
 
       ; Convert arguments object to an array
-      (var argumentsAsArray ((. Array :prototype :slice :call) arguments 0))
+      (var argumentsAsArray ((. Array 'prototype 'slice 'call) arguments 0))
 
       ; Make an eslisp list object from the arguments
-      (var args ((. this :list :apply) null argumentsAsArray))
+      (var args ((. this 'list 'apply) null argumentsAsArray))
 
       ; Make an eslisp atom representing the number of arguments
-      (var total ((. this :atom) (. arguments :length)))
+      (var total ((. this 'atom) (. arguments 'length)))
 
       ; Return a division of the sum of the arguments by the total
       (return `(/ (+ ,@args) ,total))))
@@ -179,9 +179,9 @@ list.
       ; Redefine the macro in an inner scope
       (macro one (lambda () (return '1.1))) ; "very large value of 1"
 
-      ((. console :log) (one)))
+      ((. console 'log) (one)))
 
-    ((. console :log) (one))
+    ((. console 'log) (one))
 
 <!-- !test out function-expression scope macro -->
 
@@ -266,7 +266,7 @@ call it with multiple arguments and return that.
 <!-- !test in increment twice -->
 
     (macro incrementTwice
-     (lambda (x) (return ((. this :multi) `(++ ,x) `(++ ,x)))))
+     (lambda (x) (return ((. this 'multi) `(++ ,x) `(++ ,x)))))
 
     (incrementTwice hello)
 
@@ -290,9 +290,9 @@ compile-time:
 <!-- !test in precompute -->
 
     (macro precompute
-     (lambda (list) (return ((. this :atom) ((. this :evaluate) list)))))
+     (lambda (list) (return ((. this 'atom) ((. this 'evaluate) list)))))
 
-    (precompute (+ 1 2 (* 5 (. Math :PI))))
+    (precompute (+ 1 2 (* 5 (. Math 'PI))))
 
 compiles to
 

--- a/doc/how-macros-work.markdown
+++ b/doc/how-macros-work.markdown
@@ -55,12 +55,12 @@ Yey!
 
 We could of course have written the macro function in eslisp instead:
 
-    (= (. module exports)
+    (= (. module :exports)
        (lambda (name)
-        (return ((. this list)
-                 ((. this atom) "=")
+        (return ((. this :list)
+                 ((. this :atom) "=")
                  name
-                 ((. this string) "hello")))))
+                 ((. this :string) "hello")))))
 
 That compiles to the same JS before.  In fact, you can write macros in any
 language you want, as long as you can compile it to JS before `require`-ing it
@@ -74,12 +74,12 @@ syntax for *quoting*, which makes macro return values much easier to read:
 To make macros clearer to read, eslisp has special syntax for returning stuff
 that represents code.  Let's rewrite the previous hello-assigning macro:
 
-    (= (. module exports) (lambda (name) (return `(var ,name "hello"))))
+    (= (. module :exports) (lambda (name) (return `(var ,name "hello"))))
 
 That does exactly the same thing, but it contains less of the
 `atom`/`list`/`string` constructor fluff, so it's clearer to read.  The `(.
 this list)` constructor is replaced with a `` ` `` (backtick).  The `var` atom
-no longer needs to be written explicitly as `((. this atom) var)` and there's
+no longer needs to be written explicitly as `((. this :atom) var)` and there's
 now a `,` (comma) before `name`.
 
 In various other Lisp family languages that eslisp is inspired by, the backtick
@@ -97,10 +97,10 @@ like
     module.exports = function (name) {
       return {
         type : "list",
-        values : Array.prototype.concat(
+        values : [].concat(
           [ { type : "atom", value : "var" } ],
           [ name ],
-          [ { type : "string" value : "hello" ]
+          [ { type : "string", value : "hello" } ]
         )
       };
     };
@@ -117,13 +117,13 @@ expression necessary to calculate the mean of some variables, you could do
      (lambda ()
 
       ; Convert arguments object to an array
-      (var argumentsAsArray ((. Array prototype slice call) arguments 0))
+      (var argumentsAsArray ((. Array :prototype :slice :call) arguments 0))
 
       ; Make an eslisp list object from the arguments
-      (var args ((. this list apply) null argumentsAsArray))
+      (var args ((. this :list :apply) null argumentsAsArray))
 
       ; Make an eslisp atom representing the number of arguments
-      (var total ((. this atom) (. arguments length)))
+      (var total ((. this :atom) (. arguments :length)))
 
       ; Return a division of the sum of the arguments by the total
       (return `(/ (+ ,@args) ,total))))
@@ -179,9 +179,9 @@ list.
       ; Redefine the macro in an inner scope
       (macro one (lambda () (return '1.1))) ; "very large value of 1"
 
-      ((. console log) (one)))
+      ((. console :log) (one)))
 
-    ((. console log) (one))
+    ((. console :log) (one))
 
 <!-- !test out function-expression scope macro -->
 
@@ -266,7 +266,7 @@ call it with multiple arguments and return that.
 <!-- !test in increment twice -->
 
     (macro incrementTwice
-     (lambda (x) (return ((. this multi) `(++ ,x) `(++ ,x)))))
+     (lambda (x) (return ((. this :multi) `(++ ,x) `(++ ,x)))))
 
     (incrementTwice hello)
 
@@ -290,9 +290,9 @@ compile-time:
 <!-- !test in precompute -->
 
     (macro precompute
-     (lambda (list) (return ((. this atom) ((. this evaluate) list)))))
+     (lambda (list) (return ((. this :atom) ((. this :evaluate) list)))))
 
-    (precompute (+ 1 2 (* 5 (. Math PI))))
+    (precompute (+ 1 2 (* 5 (. Math :PI))))
 
 compiles to
 

--- a/makefile
+++ b/makefile
@@ -24,4 +24,6 @@ test-docs: all doc/how-macros-work.markdown doc/basics-reference.markdown
 	@txm doc/how-macros-work.markdown
 	@txm doc/basics-reference.markdown
 
+test-all: test test-readme test-docs
+
 .PHONY: all clean test test-readme test-docs

--- a/package.json
+++ b/package.json
@@ -39,13 +39,14 @@
     "source-map": "^0.5.3",
     "tape": "^4.0.0",
     "tests-ex-markdown": "^2.0.0",
-    "tmp": "0.0.28"
+    "tmp": "0.0.28",
+    "uuid": "^2.0.1"
   },
   "dependencies": {
     "chalk": "^1.1.1",
     "concat-stream": "^1.4.7",
     "convert-source-map": "^1.1.2",
-    "escodegen": "^1.4.1",
+    "escodegen": "^1.7.1",
     "esutils": "^2.0.2",
     "esvalid": "1.1.0",
     "nopt": "^3.0.3",

--- a/readme.markdown
+++ b/readme.markdown
@@ -18,13 +18,13 @@ your own language features, [like this][9].
     ; Only include given statement if `$DEBUG` environment variable is set
     (macro debug
      (lambda (statement)
-      (return (?: (. process :env :DEBUG)
+      (return (?: (. process 'env 'DEBUG)
                   statement
                   null))))
 
     (var fib ; Fibonacci number sequence
        (lambda (x)
-        (debug ((. console :log) (+ "resolving number " x)))
+        (debug ((. console 'log) (+ "resolving number " x)))
         (switch x
          (0 (return 0))
          (1 (return 1))
@@ -132,9 +132,9 @@ arguments as the rest:
 <!-- !test in simple macros -->
 
     ; The "." macro compiles to property access.
-    (. a :b)
-    (. a :b c)
-    (. a :b 5 :c "yo")
+    (. a 'b)
+    (. a 'b c)
+    (. a 'b 5 'c "yo")
 
     ; The "+" macro compiles to addition.
     (+ 1 2)
@@ -148,7 +148,7 @@ arguments as the rest:
     a.b[5].c['yo'];
     1 + 2;
 
-If the `(. a :b)` syntax feels tedious, you might like the [eslisp-propertify][34] transform macro, which lets you write `a.b` instead.
+If the `(. a 'b)` syntax feels tedious, you might like the [eslisp-propertify][34] transform macro, which lets you write `a.b` instead.
 
 If the first element of a list isn't the name of a macro which is in scope, it
 compiles to a function call:
@@ -173,7 +173,7 @@ These can of course be nested:
     (var x (+ 1 (* 2 3)))
 
     ; Calling the result of a property access expression
-    ((. console :log) "hi")
+    ((. console 'log) "hi")
 
 <!-- !test out nested macros -->
 
@@ -295,7 +295,7 @@ Macros can use [`quasiquote`][36] (`` ` ``), `unquote` (`,`) and
 <!-- !test in macro and call -->
 
     (macro m (lambda (x) (return `(+ ,x 2))))
-    ((. console :log) (m 40))
+    ((. console 'log) (m 40))
 
 <!-- !test out macro and call -->
 
@@ -309,9 +309,9 @@ S-expression atom.
 <!-- !test in evaluate in macro -->
 
     (macro add2 (lambda (x)
-                 (var xPlusTwo (+ ((. this :evaluate) x) 2))
-                 (return ((. this :atom) xPlusTwo))))
-    ((. console :log) (add2 40))
+                 (var xPlusTwo (+ ((. this 'evaluate) x) 2))
+                 (return ((. this 'atom) xPlusTwo))))
+    ((. console 'log) (add2 40))
 
 <!-- !test out evaluate in macro -->
 
@@ -322,8 +322,8 @@ You can return multiple statements from a macro with `this.multi`.
 <!-- !test in multiple-return macro -->
 
     (macro log-and-delete (lambda (varName)
-     (return ((. this :multi)
-              `((. console :log) ((. JSON :stringify) ,varName))
+     (return ((. this 'multi)
+              `((. console 'log) ((. JSON 'stringify) ,varName))
               `(delete ,varName)))))
 
     (log-and-delete someVariable)
@@ -340,9 +340,9 @@ compilation side-effects and conditional compilation.
 
     ; Only include statement if `$DEBUG` environment variable is set
     (macro debug (lambda (statement)
-     (return (?: (. process :env :DEBUG) statement null))))
+     (return (?: (. process 'env 'DEBUG) statement null))))
 
-    (debug ((. console :log) "debug output"))
+    (debug ((. console 'log) "debug output"))
     (yep)
 
 <!-- !test out nothing-returning macro -->
@@ -360,9 +360,9 @@ and the variables in the IIFE are shared between them.
     (macro ((lambda ()
             (var x 0) ; visible to all of the macro functions
             (return
-             (object (:increment (lambda () (return ((. this :atom) (++ x)))))
-                     (:decrement (lambda () (return ((. this :atom) (-- x)))))
-                     (:get       (lambda () (return ((. this :atom) x)))))))))
+             (object ('increment (lambda () (return ((. this 'atom) (++ x)))))
+                     ('decrement (lambda () (return ((. this 'atom) (-- x)))))
+                     ('get       (lambda () (return ((. this 'atom) x)))))))))
 
     (increment)
     (increment)
@@ -417,7 +417,7 @@ The compiler runs as a [REPL][42] if given no arguments, though it doesn't
 
 You can also just pipe data to it to compile it if you want.
 
-    echo '((. console :log) "Yo!")' | eslc
+    echo '((. console 'log) "Yo!")' | eslc
 
 Or pass a filename, like `eslc myprogram.esl`.
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -18,13 +18,13 @@ your own language features, [like this][9].
     ; Only include given statement if `$DEBUG` environment variable is set
     (macro debug
      (lambda (statement)
-      (return (?: (. process env DEBUG)
+      (return (?: (. process :env :DEBUG)
                   statement
                   null))))
 
     (var fib ; Fibonacci number sequence
        (lambda (x)
-        (debug ((. console log) (+ "resolving number " x)))
+        (debug ((. console :log) (+ "resolving number " x)))
         (switch x
          (0 (return 0))
          (1 (return 1))
@@ -132,8 +132,9 @@ arguments as the rest:
 <!-- !test in simple macros -->
 
     ; The "." macro compiles to property access.
-    (. a b)
-    (. a b 5 c "yo")
+    (. a :b)
+    (. a :b c)
+    (. a :b 5 :c "yo")
 
     ; The "+" macro compiles to addition.
     (+ 1 2)
@@ -143,10 +144,11 @@ arguments as the rest:
 <!-- !test out simple macros -->
 
     a.b;
+    a.b[c];
     a.b[5].c['yo'];
     1 + 2;
 
-If the `(. a b)` syntax feels tedious, you might like the [eslisp-propertify][34] transform macro, which lets you write `a.b` instead.
+If the `(. a :b)` syntax feels tedious, you might like the [eslisp-propertify][34] transform macro, which lets you write `a.b` instead.
 
 If the first element of a list isn't the name of a macro which is in scope, it
 compiles to a function call:
@@ -171,7 +173,7 @@ These can of course be nested:
     (var x (+ 1 (* 2 3)))
 
     ; Calling the result of a property access expression
-    ((. console log) "hi")
+    ((. console :log) "hi")
 
 <!-- !test out nested macros -->
 
@@ -293,7 +295,7 @@ Macros can use [`quasiquote`][36] (`` ` ``), `unquote` (`,`) and
 <!-- !test in macro and call -->
 
     (macro m (lambda (x) (return `(+ ,x 2))))
-    ((. console log) (m 40))
+    ((. console :log) (m 40))
 
 <!-- !test out macro and call -->
 
@@ -307,9 +309,9 @@ S-expression atom.
 <!-- !test in evaluate in macro -->
 
     (macro add2 (lambda (x)
-                 (var xPlusTwo (+ ((. this evaluate) x) 2))
-                 (return ((. this atom) xPlusTwo))))
-    ((. console log) (add2 40))
+                 (var xPlusTwo (+ ((. this :evaluate) x) 2))
+                 (return ((. this :atom) xPlusTwo))))
+    ((. console :log) (add2 40))
 
 <!-- !test out evaluate in macro -->
 
@@ -320,8 +322,8 @@ You can return multiple statements from a macro with `this.multi`.
 <!-- !test in multiple-return macro -->
 
     (macro log-and-delete (lambda (varName)
-     (return ((. this multi)
-              `((. console log) ((. JSON stringify) ,varName))
+     (return ((. this :multi)
+              `((. console :log) ((. JSON :stringify) ,varName))
               `(delete ,varName)))))
 
     (log-and-delete someVariable)
@@ -338,9 +340,9 @@ compilation side-effects and conditional compilation.
 
     ; Only include statement if `$DEBUG` environment variable is set
     (macro debug (lambda (statement)
-     (return (?: (. process env DEBUG) statement null))))
+     (return (?: (. process :env :DEBUG) statement null))))
 
-    (debug ((. console log) "debug output"))
+    (debug ((. console :log) "debug output"))
     (yep)
 
 <!-- !test out nothing-returning macro -->
@@ -358,9 +360,9 @@ and the variables in the IIFE are shared between them.
     (macro ((lambda ()
             (var x 0) ; visible to all of the macro functions
             (return
-             (object increment (lambda () (return ((. this atom) (++ x))))
-                     decrement (lambda () (return ((. this atom) (-- x))))
-                     get       (lambda () (return ((. this atom) x))))))))
+             (object (:increment (lambda () (return ((. this :atom) (++ x)))))
+                     (:decrement (lambda () (return ((. this :atom) (-- x)))))
+                     (:get       (lambda () (return ((. this :atom) x)))))))))
 
     (increment)
     (increment)
@@ -415,7 +417,7 @@ The compiler runs as a [REPL][42] if given no arguments, though it doesn't
 
 You can also just pipe data to it to compile it if you want.
 
-    echo '((. console log) "Yo!")' | eslc
+    echo '((. console :log) "Yo!")' | eslc
 
 Or pass a filename, like `eslc myprogram.esl`.
 

--- a/src/translate.ls
+++ b/src/translate.ls
@@ -1,7 +1,7 @@
 # Turns an internal AST form into an estree object with reference to the given
 # root environment.  Throws error unless the resulting estree AST is valid.
 
-{ concat-map }   = require \prelude-ls
+{ concat-map, reject }   = require \prelude-ls
 root-macro-table = require \./built-in-macros
 statementify     = require \./es-statementify
 environment      = require \./env
@@ -30,7 +30,13 @@ module.exports = (root-env, ast, options={}) ->
            |> (.filter (isnt null)) # because macro definitions emit null
            |> (.map statementify)
 
-  err = errors program-ast
+  err = errors program-ast |> reject ({node}) ->
+    # These are valid ES6 nodes, and their errors need to be ignored. See
+    # https://github.com/estools/esvalid/issues/7.
+    | node.type is \Property =>
+      node.computed and node.key?.type not in <[Identifier Literal]>
+    | otherwise => false
+
   if err.length
     first-error = err.0
     throw first-error

--- a/test.ls
+++ b/test.ls
@@ -239,7 +239,7 @@ test "return statement" ->
     ..`@equals` "(function () {\n    return 'hello there';\n});"
 
 test "member expression" ->
-  esl "(. console :log)"
+  esl "(. console 'log)"
     ..`@equals` "console.log;"
 
 test "explicit block statement" ->
@@ -251,17 +251,17 @@ test "call expression" ->
     ..`@equals` "f();"
 
 test "member, then call with arguments" ->
-  esl '((. console :log) "hi")'
+  esl '((. console \'log) "hi")'
     ..`@equals` "console.log('hi');"
 
 test "func with member and call in it" ->
-  esl "(lambda (x) ((. console :log) x))"
+  esl "(lambda (x) ((. console 'log) x))"
     ..`@equals` "(function (x) {\n    console.log(x);\n});"
 
 test "switch statement" ->
   esl '''
       (switch (y)
-              ((== x 5) ((. console :log) "hi") (break))
+              ((== x 5) ((. console 'log) "hi") (break))
               (default  (yes)))
       '''
     ..`@equals` """
@@ -275,7 +275,7 @@ test "switch statement" ->
                 """
 
 test "if-statement with blocks" ->
-  esl '(if (+ 1 0) (block ((. console :log) "yes") (x)) (block 0))'
+  esl '(if (+ 1 0) (block ((. console \'log) "yes") (x)) (block 0))'
     ..`@equals` """
       if (1 + 0) {
           console.log(\'yes\');
@@ -295,7 +295,7 @@ test "if-statement with expressions" ->
       """
 
 test "if-statement without alternate" ->
-  esl '(if (+ 1 0) (block ((. console :log) "yes") (x)))'
+  esl '(if (+ 1 0) (block ((. console \'log) "yes") (x)))'
     ..`@equals` """
       if (1 + 0) {
           console.log(\'yes\');
@@ -309,8 +309,8 @@ test "ternary expression" ->
 
 test "while loop with explicit body" ->
   esl '(while (-- n) (block
-                      ((. console :log) "ok")
-                      ((. console :log) "still ok")))'
+                      ((. console \'log) "ok")
+                      ((. console \'log) "still ok")))'
     ..`@equals` "while (--n) {\n    console.log('ok');\n    console.log('still ok');\n}"
 
 test "while loop with explicit body that contains a block" ->
@@ -319,29 +319,29 @@ test "while loop with explicit body that contains a block" ->
     ..`@equals` "while (--n) {\n    {\n        a;\n    }\n}"
 
 test "while loop with implicit body" ->
-  esl '(while (-- n) ((. console :log) "ok")
-                     ((. console :log) "still ok"))'
+  esl '(while (-- n) ((. console \'log) "ok")
+                     ((. console \'log) "still ok"))'
     ..`@equals` "while (--n) {\n    console.log('ok');\n    console.log('still ok');\n}"
 
 test "do/while loop with implicit body" ->
-  esl '(dowhile (-- n) ((. console :log) "ok")
-                     ((. console :log) "still ok"))'
+  esl '(dowhile (-- n) ((. console \'log) "ok")
+                       ((. console \'log) "still ok"))'
     ..`@equals` "do {\n    console.log('ok');\n    console.log('still ok');\n} while (--n);"
 
 test "do/while loop with explicit body" ->
   esl '(dowhile (-- n) (block
-                        ((. console :log) "ok")
-                        ((. console :log) "still ok")))'
+                        ((. console \'log) "ok")
+                        ((. console \'log) "still ok")))'
     ..`@equals` "do {\n    console.log('ok');\n    console.log('still ok');\n} while (--n);"
 
 test "for loop with implicit body" ->
-  esl '(for (var x 1) (< x 10) (++ x) ((. console :log) "ok")
-                                    ((. console :log) "still ok"))'
+  esl '(for (var x 1) (< x 10) (++ x) ((. console \'log) "ok")
+                                      ((. console \'log) "still ok"))'
     ..`@equals` "for (var x = 1; x < 10; ++x) {\n    console.log('ok');\n    console.log('still ok');\n}"
 
 test "for loop with explicit body" ->
-  esl '(for (var x 1) (< x 10) (++ x) (block ((. console :log) "ok")
-                                           ((. console :log) "still ok")))'
+  esl '(for (var x 1) (< x 10) (++ x) (block ((. console \'log) "ok")
+                                             ((. console \'log) "still ok")))'
     ..`@equals` "for (var x = 1; x < 10; ++x) {\n    console.log('ok');\n    console.log('still ok');\n}"
 
 test "for loop with no body" ->
@@ -349,36 +349,36 @@ test "for loop with no body" ->
     ..`@equals` "for (var x = 1; x < 10; ++x) {\n}"
 
 test "for loop with null update" ->
-  esl '(for (var x 1) (< x 10) () ((. console :log) "ok")
-                                ((. console :log) "still ok"))'
+  esl '(for (var x 1) (< x 10) () ((. console \'log) "ok")
+                                  ((. console \'log) "still ok"))'
     ..`@equals` "for (var x = 1; x < 10;) {\n    console.log('ok');\n    console.log('still ok');\n}"
 
 test "for loop with null init, update and test" ->
-  esl '(for () () () ((. console :log) "ok")
-                     ((. console :log) "still ok"))'
+  esl '(for () () () ((. console \'log) "ok")
+                     ((. console \'log) "still ok"))'
     ..`@equals` "for (;;) {\n    console.log('ok');\n    console.log('still ok');\n}"
 
 test "for-in loop with implicit body" ->
-  esl '(forin (var x) xs ((. console :log) x))'
+  esl '(forin (var x) xs ((. console \'log) x))'
     ..`@equals` "for (var x in xs) {\n    console.log(x);\n}"
 
 test "for-in loop with explicit body" ->
-  esl '(forin (var x) xs (block ((. console :log) x)))'
+  esl '(forin (var x) xs (block ((. console \'log) x)))'
     ..`@equals` "for (var x in xs) {\n    console.log(x);\n}"
 
 test "multiple statements in program" ->
-  esl '((. console :log) "hello") ((. console :log) "world")'
+  esl '((. console \'log) "hello") ((. console \'log) "world")'
     ..`@equals` "console.log('hello');\nconsole.log('world');"
 
 test "function with implicit block body" ->
-  esl '(lambda (x) ((. console :log) "hello") \
-                   ((. console :log) "world"))'
+  esl '(lambda (x) ((. console \'log) "hello") \
+                   ((. console \'log) "world"))'
     ..`@equals` "(function (x) {\n    console.log(\'hello\');\n    console.log(\'world\');\n});"
 
 test "function with explicit block body" ->
   esl '(lambda (x) (block
-                      ((. console :log) "hello") \
-                      ((. console :log) "world")))'
+                      ((. console \'log) "hello") \
+                      ((. console \'log) "world")))'
     ..`@equals` "(function (x) {\n    console.log(\'hello\');\n    console.log(\'world\');\n});"
 
 test "new statement" ->
@@ -546,14 +546,14 @@ test "quoting atoms produces an object representing it" ->
       ..value `@equals` "fun"
 
 test "simple quoting macro" ->
-  esl "(macro random (lambda () (return '((. Math :random)))))
+  esl "(macro random (lambda () (return '((. Math 'random)))))
        (+ (random) (random))"
     ..`@equals` "Math.random() + Math.random();"
 
 test "macro constructor given object imports properties as macros" ->
   esl '''
-      (macro (object (:a (lambda () (return '"hi a")))
-                     (:b (lambda () (return '"hi b")))))
+      (macro (object ('a (lambda () (return '"hi a")))
+                     ('b (lambda () (return '"hi b")))))
       (a) (b)
       '''
    ..`@equals` "'hi a';\n'hi b';"
@@ -580,7 +580,7 @@ test "nothing-returning macro" ->
 
 test "macros mask others defined before with the same name" ->
   esl "(macro m (lambda () (return ())))
-       (macro m (lambda () (return '((. console :log) \"hi\"))))
+       (macro m (lambda () (return '((. console 'log) \"hi\"))))
        (m)"
     ..`@equals` "console.log('hi');"
 
@@ -615,20 +615,20 @@ test "dead simple quasiquote" ->
 test "quasiquote is like quote if no unquotes contained" ->
   esl "(macro rand (lambda ()
                   (return `(* 5
-                      ((. Math :random))))))
+                      ((. Math 'random))))))
        (rand)"
     ..`@equals` "5 * Math.random();"
 
 test "macros can quasiquote to unquote arguments into output" ->
   esl "(macro rand (lambda (upper)
                   (return `(* ,upper
-                      ((. Math :random))))))
+                      ((. Math 'random))))))
        (rand 5)"
     ..`@equals` "5 * Math.random();"
 
 test "macro env can create atoms out of strings or numbers" ->
   esl """
-      (macro m (lambda () (return ((. this :atom) 42))))
+      (macro m (lambda () (return ((. this 'atom) 42))))
       (m)"""
     ..`@equals` "42;"
 
@@ -640,17 +640,17 @@ test "macro env can create sexpr AST nodes equivalently to quoting" ->
   with-construct =
     esl """
         (macro m (lambda ()
-                  (return ((. this :list)
-                           ((. this :atom) "a")
-                           ((. this :string) "b")))))
+                  (return ((. this 'list)
+                           ((. this 'atom) "a")
+                           ((. this 'string) "b")))))
         (m)"""
   with-quote `@equals` with-construct
 
 test "macros can evaluate number arguments to JS and convert them back again" ->
   esl """
        (macro incrementedTimesTwo (lambda (x)
-                    (var y (+ 1 ((. this :evaluate) x)))
-                    (var xAsSexpr ((. this :atom) ((. y :toString))))
+                    (var y (+ 1 ((. this 'evaluate) x)))
+                    (var xAsSexpr ((. this 'atom) ((. y 'toString))))
                     (return `(* ,xAsSexpr 2))))
        (incrementedTimesTwo 5)
        """
@@ -661,9 +661,9 @@ test "macros can evaluate object arguments" ->
   # to an object, then stringifies it.
   esl """
        (macro objectAsString (lambda (input)
-                    (= obj ((. this :evaluate) input))
-                    (return ((. this :string) ((. JSON :stringify) obj)))))
-       (objectAsString (object (:a 1)))
+                    (= obj ((. this 'evaluate) input))
+                    (return ((. this 'string) ((. JSON 'stringify) obj)))))
+       (objectAsString (object ('a 1)))
        """
     ..`@equals` "'{\"a\":1}';"
 
@@ -672,10 +672,10 @@ test "macros can evaluate statements" ->
   # statement does not evaluate to a value, so we check for undefined.
   esl """
        (macro evalThis (lambda (input)
-                    (= obj ((. this :evaluate) input))
+                    (= obj ((. this 'evaluate) input))
                     (if (=== obj undefined)
-                        (return ((. this :atom) "yep"))
-                        (return ((. this :atom) "nope")))))
+                        (return ((. this 'atom) "yep"))
+                        (return ((. this 'atom) "nope")))))
        (evalThis (if 1 (block) (block)))
        """
     ..`@equals` "yep;"
@@ -702,8 +702,8 @@ test "quasiquote can contain nested lists" ->
        (lambda ()
         ; Convert arguments into array
         (var args
-             ((. this :list :apply) null ((. Array :prototype :slice :call) arguments 0)))
-        (var total ((. this :atom) ((. (. args :values :length) :toString))))
+             ((. this 'list 'apply) null ((. Array 'prototype 'slice 'call) arguments 0)))
+        (var total ((. this 'atom) ((. (. args 'values 'length) 'toString))))
         (return `(/ (+ ,@args) ,total))))
        (mean 1 2 3)
       '''
@@ -718,7 +718,7 @@ test "array macro can be empty" ->
     ..`@equals` "[];"
 
 test "object macro produces object expression" ->
-  esl "(object (:a 1) (:b 2))"
+  esl "(object ('a 1) ('b 2))"
     ..`@equals` "({\n    a: 1,\n    b: 2\n});"
 
 test "object macro can be passed strings as keys too" ->
@@ -730,7 +730,7 @@ test "object macro's value parts can be expressions" ->
     ..`@equals` "({\n    'a': 1 + 2,\n    'b': f(x)\n});"
 
 test "object macro's parts can be ES6 shorthands" ->
-  esl '(object (:a) (:b))'
+  esl '(object (\'a) (\'b))'
     ..`@equals` "({\n    a,\n    b\n});"
 
 test "object macro's key parts can be computed ES6 values" ->
@@ -738,11 +738,11 @@ test "object macro's key parts can be computed ES6 values" ->
     ..`@equals` "({\n    [a]: 1 + 2,\n    [b]: f(x)\n});"
 
 test "object macro can create getters" ->
-  esl '(object (get :a () (return 1)))'
+  esl '(object (get \'a () (return 1)))'
     ..`@equals` '({\n    get a() {\n        return 1;\n    }\n});'
 
 test "object macro can create setters" ->
-  esl '(object (set :a (x) (return 1)))'
+  esl '(object (set \'a (x) (return 1)))'
     ..`@equals` '({\n    set a(x) {\n        return 1;\n    }\n});'
 
 test "object macro can create computed getters and setters" ->
@@ -759,8 +759,8 @@ test "object macro can create computed getters and setters" ->
 test "object macro's parts can be ES6 methods" ->
   esl '''
       (object
-        (:a () (return 1))
-        (:b (x) (return (+ x 1)))
+        ('a () (return 1))
+        ('b (x) (return (+ x 1)))
         (c (x y) (return (+ x y 1))))
       '''
     ..`@equals` """
@@ -780,27 +780,27 @@ test "object macro's parts can be ES6 methods" ->
 test "object macro compiles complex ES6 object" ->
   esl '''
       (object
-        (:prop)
-        (:_foo 1)
-        ((. Symbol :toStringTag) "Foo")
+        ('prop)
+        ('_foo 1)
+        ((. Symbol 'toStringTag) "Foo")
 
-        (get :foo ()
-          (return (. this :_foo)))
+        (get 'foo ()
+          (return (. this '_foo)))
 
-        (set :foo (value)
-          (= (. this :_foo) value))
+        (set 'foo (value)
+          (= (. this '_foo) value))
 
-        (get (. syms :Sym) ()
-          (return ((. wm :get) this)))
+        (get (. syms 'Sym) ()
+          (return ((. wm 'get) this)))
 
-        (set (. syms :Sym) (value)
-          ((. wm :set) this value))
+        (set (. syms 'Sym) (value)
+          ((. wm 'set) this value))
 
-        (:printFoo ()
-          ((. console :log) (. this :foo)))
+        ('printFoo ()
+          ((. console 'log) (. this 'foo)))
 
-        (:concatFoo (value)
-          (return (+ (. this :foo) value))))
+        ('concatFoo (value)
+          (return (+ (. this 'foo) value))))
       '''
     ..`@equals` '''
     ({
@@ -829,7 +829,7 @@ test "object macro compiles complex ES6 object" ->
     '''
 
 test "macro producing an object literal" ->
-  esl "(macro obj (lambda () (return '(object (:a 1)))))
+  esl "(macro obj (lambda () (return '(object ('a 1)))))
        (obj)"
     ..`@equals` "({ a: 1 });"
 
@@ -840,7 +840,7 @@ test "macro producing a function" ->
     ..`@equals` "(function (x) {\n    return x + 3;\n});"
 
 test "property access (dotting) chains identifiers" ->
-  esl "(. a :b :c)"
+  esl "(. a 'b 'c)"
     ..`@equals` "a.b.c;"
 
 test "property access (dotting) chains computed identifiers" ->
@@ -852,15 +852,15 @@ test "property access (dotting) chains literals" ->
     ..`@equals` "a[1][2];"
 
 test "property access (dotting) can be nested" ->
-  esl "(. a (. a (. b :name)))"
+  esl "(. a (. a (. b 'name)))"
     ..`@equals` "a[a[b.name]];"
 
 test "property access (dotting) chains mixed literals and identifiers" ->
-  esl "(. a :b 2 :a)"
+  esl "(. a 'b 2 'a)"
     ..`@equals` "a.b[2].a;"
 
 test "property access (dotting) chains mixed literals and values" ->
-  esl "(. a b 2 :a)"
+  esl "(. a b 2 'a)"
     ..`@equals` "a[b][2].a;"
 
 test "property access (dotting) treats strings as literals, not identifiers" ->
@@ -890,7 +890,7 @@ test "regex can be given atoms with escaped spaces and slashes" ->
 test "macro deliberately breaking hygiene for function argument anaphora" ->
   esl "(macro : (lambda (body)
        (return `(lambda (it) ,body))))
-        (: (return (. it :x)))"
+        (: (return (. it 'x)))"
     ..`@equals` "(function (it) {\n    return it.x;\n});"
 
 test "macro given nothing produces no output" ->
@@ -904,12 +904,12 @@ test "when returned from an IIFE, macros can share state" ->
       (macro
        ((lambda () (var x 0)
         (return (object
-                 (:plusPrev  (lambda (n)
-                                   (+= x ((. this :evaluate) n))
-                                   (return ((. this :atom) ((. x :toString))))))
-                 (:timesPrev (lambda (n)
-                                   (*= x ((. this :evaluate) n))
-                                   (return ((. this :atom) ((. x :toString)))))))))))
+                 ('plusPrev  (lambda (n)
+                                   (+= x ((. this 'evaluate) n))
+                                   (return ((. this 'atom) ((. x 'toString))))))
+                 ('timesPrev (lambda (n)
+                                   (*= x ((. this 'evaluate) n))
+                                   (return ((. this 'atom) ((. x 'toString)))))))))))
       (plusPrev 2) (timesPrev 2)
        """
    ..`@equals` "2;\n4;"
@@ -925,17 +925,17 @@ test "macro constructor loading from IIFE can load nothing" ->
    ..`@equals` ""
 
 test "macro can return multiple statements with `multi`" ->
-  esl "(macro declareTwo (lambda () (return ((. this :multi) '(var x 0) '(var y 1)))))
+  esl "(macro declareTwo (lambda () (return ((. this 'multi) '(var x 0) '(var y 1)))))
        (declareTwo)"
    ..`@equals` "var x = 0;\nvar y = 1;"
 
 test "macro can check argument type and get its value" ->
   esl '''
       (macro stringy (lambda (x)
-       (if (== (. x :type) "atom")
-        (return ((. this :string) (+ "atom:" (. x :value))))
+       (if (== (. x 'type) "atom")
+        (return ((. this 'string) (+ "atom:" (. x 'value))))
         (block
-         (if (== (. x :type) "string")
+         (if (== (. x 'type) "string")
           (return x)
           (return "An unexpected development!"))))))
       (stringy a)
@@ -948,7 +948,7 @@ test "macro returning atom with empty or null name fails" ->
   <[ "" null undefined ]>.for-each ->
     self.throws do
       -> esl """
-          (macro mac (lambda () (return ((. this :atom) #it))))
+          (macro mac (lambda () (return ((. this 'atom) #it))))
           (mac)
           """
       Error
@@ -970,7 +970,7 @@ test "macros can be required relative to root directory" ->
   main-path = path.join dir-name, main-basename
   main-fd = fs.open-sync main-path, \a+
   fs.write-sync main-fd, """
-    (macro (object (:x (require "./#module-basename"))))
+    (macro (object ('x (require "./#module-basename"))))
     (x)
     """
 
@@ -1007,7 +1007,7 @@ test "macros can be required from node_modules relative to root directory" ->
   # Attempt to require it and use it as a macro
 
   esl """
-    (macro (object (:x (require "#module-name"))))
+    (macro (object ('x (require "#module-name"))))
     (x)
     """
     ..`@equals` ""
@@ -1029,7 +1029,7 @@ test "macros required from separate modules can access complation env" ->
     """
 
   code = esl """
-    (macro (object (:x (require "#name"))))
+    (macro (object ('x (require "#name"))))
     (x)
     """
 
@@ -1074,7 +1074,7 @@ test "macro-generating macro" -> # yes srsly
 test "macro generating macro and macro call" -> # yes srsly squared
   esl '''
     (macro define-and-call (lambda (x)
-      (return ((. this :multi) `(macro what (lambda () (return `(hello))))
+      (return ((. this 'multi) `(macro what (lambda () (return `(hello))))
                               `(what)))))
     (define-and-call)
     '''
@@ -1113,7 +1113,7 @@ test "invalid AST returned by macro throws error" ->
 test "macro multi-returning with bad values throws descriptive error" ->
   try
     esl '''
-      (macro breaking (lambda () (return ((. this :multi) null))))
+      (macro breaking (lambda () (return ((. this 'multi) null))))
       (breaking)
       '''
   catch e
@@ -1144,7 +1144,7 @@ test "macro can return estree object" ->
 test "macro can multi-return estree objects" ->
   esl '''
     (macro identifiers (lambda ()
-      (return ((. this :multi)
+      (return ((. this 'multi)
                (object ("type" "Identifier")
                        ("name" "x"))
                (object ("type" "Identifier")
@@ -1156,7 +1156,7 @@ test "macro can multi-return estree objects" ->
 test "macro can multi-return a combination of estree and sexprs" ->
   esl '''
     (macro identifiers (lambda ()
-      (return ((. this :multi)
+      (return ((. this 'multi)
                (object ("type" "Identifier")
                        ("name" "x"))
                'x))))
@@ -1167,11 +1167,11 @@ test "macro can multi-return a combination of estree and sexprs" ->
 test "macro can compile and return parameter as estree" ->
   esl '''
     (macro that (lambda (x)
-      (return ((. this :compile) x))))
+      (return ((. this 'compile) x))))
     (that 3)
     (that "hi")
     (that (c))
-    (that (object (:a b)))
+    (that (object ('a b)))
     '''
       ..`@equals` "3;\n'hi';\nc();\n({ a: b });"
 

--- a/test.ls
+++ b/test.ls
@@ -239,7 +239,7 @@ test "return statement" ->
     ..`@equals` "(function () {\n    return 'hello there';\n});"
 
 test "member expression" ->
-  esl "(. console log)"
+  esl "(. console :log)"
     ..`@equals` "console.log;"
 
 test "explicit block statement" ->
@@ -251,17 +251,17 @@ test "call expression" ->
     ..`@equals` "f();"
 
 test "member, then call with arguments" ->
-  esl '((. console log) "hi")'
+  esl '((. console :log) "hi")'
     ..`@equals` "console.log('hi');"
 
 test "func with member and call in it" ->
-  esl "(lambda (x) ((. console log) x))"
+  esl "(lambda (x) ((. console :log) x))"
     ..`@equals` "(function (x) {\n    console.log(x);\n});"
 
 test "switch statement" ->
   esl '''
       (switch (y)
-              ((== x 5) ((. console log) "hi") (break))
+              ((== x 5) ((. console :log) "hi") (break))
               (default  (yes)))
       '''
     ..`@equals` """
@@ -275,7 +275,7 @@ test "switch statement" ->
                 """
 
 test "if-statement with blocks" ->
-  esl '(if (+ 1 0) (block ((. console log) "yes") (x)) (block 0))'
+  esl '(if (+ 1 0) (block ((. console :log) "yes") (x)) (block 0))'
     ..`@equals` """
       if (1 + 0) {
           console.log(\'yes\');
@@ -295,7 +295,7 @@ test "if-statement with expressions" ->
       """
 
 test "if-statement without alternate" ->
-  esl '(if (+ 1 0) (block ((. console log) "yes") (x)))'
+  esl '(if (+ 1 0) (block ((. console :log) "yes") (x)))'
     ..`@equals` """
       if (1 + 0) {
           console.log(\'yes\');
@@ -309,8 +309,8 @@ test "ternary expression" ->
 
 test "while loop with explicit body" ->
   esl '(while (-- n) (block
-                      ((. console log) "ok")
-                      ((. console log) "still ok")))'
+                      ((. console :log) "ok")
+                      ((. console :log) "still ok")))'
     ..`@equals` "while (--n) {\n    console.log('ok');\n    console.log('still ok');\n}"
 
 test "while loop with explicit body that contains a block" ->
@@ -319,29 +319,29 @@ test "while loop with explicit body that contains a block" ->
     ..`@equals` "while (--n) {\n    {\n        a;\n    }\n}"
 
 test "while loop with implicit body" ->
-  esl '(while (-- n) ((. console log) "ok")
-                     ((. console log) "still ok"))'
+  esl '(while (-- n) ((. console :log) "ok")
+                     ((. console :log) "still ok"))'
     ..`@equals` "while (--n) {\n    console.log('ok');\n    console.log('still ok');\n}"
 
 test "do/while loop with implicit body" ->
-  esl '(dowhile (-- n) ((. console log) "ok")
-                     ((. console log) "still ok"))'
+  esl '(dowhile (-- n) ((. console :log) "ok")
+                     ((. console :log) "still ok"))'
     ..`@equals` "do {\n    console.log('ok');\n    console.log('still ok');\n} while (--n);"
 
 test "do/while loop with explicit body" ->
   esl '(dowhile (-- n) (block
-                        ((. console log) "ok")
-                        ((. console log) "still ok")))'
+                        ((. console :log) "ok")
+                        ((. console :log) "still ok")))'
     ..`@equals` "do {\n    console.log('ok');\n    console.log('still ok');\n} while (--n);"
 
 test "for loop with implicit body" ->
-  esl '(for (var x 1) (< x 10) (++ x) ((. console log) "ok")
-                                    ((. console log) "still ok"))'
+  esl '(for (var x 1) (< x 10) (++ x) ((. console :log) "ok")
+                                    ((. console :log) "still ok"))'
     ..`@equals` "for (var x = 1; x < 10; ++x) {\n    console.log('ok');\n    console.log('still ok');\n}"
 
 test "for loop with explicit body" ->
-  esl '(for (var x 1) (< x 10) (++ x) (block ((. console log) "ok")
-                                           ((. console log) "still ok")))'
+  esl '(for (var x 1) (< x 10) (++ x) (block ((. console :log) "ok")
+                                           ((. console :log) "still ok")))'
     ..`@equals` "for (var x = 1; x < 10; ++x) {\n    console.log('ok');\n    console.log('still ok');\n}"
 
 test "for loop with no body" ->
@@ -349,36 +349,36 @@ test "for loop with no body" ->
     ..`@equals` "for (var x = 1; x < 10; ++x) {\n}"
 
 test "for loop with null update" ->
-  esl '(for (var x 1) (< x 10) () ((. console log) "ok")
-                                ((. console log) "still ok"))'
+  esl '(for (var x 1) (< x 10) () ((. console :log) "ok")
+                                ((. console :log) "still ok"))'
     ..`@equals` "for (var x = 1; x < 10;) {\n    console.log('ok');\n    console.log('still ok');\n}"
 
 test "for loop with null init, update and test" ->
-  esl '(for () () () ((. console log) "ok")
-                     ((. console log) "still ok"))'
+  esl '(for () () () ((. console :log) "ok")
+                     ((. console :log) "still ok"))'
     ..`@equals` "for (;;) {\n    console.log('ok');\n    console.log('still ok');\n}"
 
 test "for-in loop with implicit body" ->
-  esl '(forin (var x) xs ((. console log) x))'
+  esl '(forin (var x) xs ((. console :log) x))'
     ..`@equals` "for (var x in xs) {\n    console.log(x);\n}"
 
 test "for-in loop with explicit body" ->
-  esl '(forin (var x) xs (block ((. console log) x)))'
+  esl '(forin (var x) xs (block ((. console :log) x)))'
     ..`@equals` "for (var x in xs) {\n    console.log(x);\n}"
 
 test "multiple statements in program" ->
-  esl '((. console log) "hello") ((. console log) "world")'
+  esl '((. console :log) "hello") ((. console :log) "world")'
     ..`@equals` "console.log('hello');\nconsole.log('world');"
 
 test "function with implicit block body" ->
-  esl '(lambda (x) ((. console log) "hello") \
-                   ((. console log) "world"))'
+  esl '(lambda (x) ((. console :log) "hello") \
+                   ((. console :log) "world"))'
     ..`@equals` "(function (x) {\n    console.log(\'hello\');\n    console.log(\'world\');\n});"
 
 test "function with explicit block body" ->
   esl '(lambda (x) (block
-                      ((. console log) "hello") \
-                      ((. console log) "world")))'
+                      ((. console :log) "hello") \
+                      ((. console :log) "world")))'
     ..`@equals` "(function (x) {\n    console.log(\'hello\');\n    console.log(\'world\');\n});"
 
 test "new statement" ->
@@ -546,14 +546,14 @@ test "quoting atoms produces an object representing it" ->
       ..value `@equals` "fun"
 
 test "simple quoting macro" ->
-  esl "(macro random (lambda () (return '((. Math random)))))
+  esl "(macro random (lambda () (return '((. Math :random)))))
        (+ (random) (random))"
     ..`@equals` "Math.random() + Math.random();"
 
 test "macro constructor given object imports properties as macros" ->
   esl '''
-      (macro (object a (lambda () (return '"hi a"))
-                     b (lambda () (return '"hi b"))))
+      (macro (object (:a (lambda () (return '"hi a")))
+                     (:b (lambda () (return '"hi b")))))
       (a) (b)
       '''
    ..`@equals` "'hi a';\n'hi b';"
@@ -580,7 +580,7 @@ test "nothing-returning macro" ->
 
 test "macros mask others defined before with the same name" ->
   esl "(macro m (lambda () (return ())))
-       (macro m (lambda () (return '((. console log) \"hi\"))))
+       (macro m (lambda () (return '((. console :log) \"hi\"))))
        (m)"
     ..`@equals` "console.log('hi');"
 
@@ -615,20 +615,20 @@ test "dead simple quasiquote" ->
 test "quasiquote is like quote if no unquotes contained" ->
   esl "(macro rand (lambda ()
                   (return `(* 5
-                      ((. Math random))))))
+                      ((. Math :random))))))
        (rand)"
     ..`@equals` "5 * Math.random();"
 
 test "macros can quasiquote to unquote arguments into output" ->
   esl "(macro rand (lambda (upper)
                   (return `(* ,upper
-                      ((. Math random))))))
+                      ((. Math :random))))))
        (rand 5)"
     ..`@equals` "5 * Math.random();"
 
 test "macro env can create atoms out of strings or numbers" ->
   esl """
-      (macro m (lambda () (return ((. this atom) 42))))
+      (macro m (lambda () (return ((. this :atom) 42))))
       (m)"""
     ..`@equals` "42;"
 
@@ -640,17 +640,17 @@ test "macro env can create sexpr AST nodes equivalently to quoting" ->
   with-construct =
     esl """
         (macro m (lambda ()
-                  (return ((. this list)
-                           ((. this atom) "a")
-                           ((. this string) "b")))))
+                  (return ((. this :list)
+                           ((. this :atom) "a")
+                           ((. this :string) "b")))))
         (m)"""
   with-quote `@equals` with-construct
 
 test "macros can evaluate number arguments to JS and convert them back again" ->
   esl """
        (macro incrementedTimesTwo (lambda (x)
-                    (var y (+ 1 ((. this evaluate) x)))
-                    (var xAsSexpr ((. this atom) ((. y toString))))
+                    (var y (+ 1 ((. this :evaluate) x)))
+                    (var xAsSexpr ((. this :atom) ((. y :toString))))
                     (return `(* ,xAsSexpr 2))))
        (incrementedTimesTwo 5)
        """
@@ -661,9 +661,9 @@ test "macros can evaluate object arguments" ->
   # to an object, then stringifies it.
   esl """
        (macro objectAsString (lambda (input)
-                    (= obj ((. this evaluate) input))
-                    (return ((. this string) ((. JSON stringify) obj)))))
-       (objectAsString (object a 1))
+                    (= obj ((. this :evaluate) input))
+                    (return ((. this :string) ((. JSON :stringify) obj)))))
+       (objectAsString (object (:a 1)))
        """
     ..`@equals` "'{\"a\":1}';"
 
@@ -672,10 +672,10 @@ test "macros can evaluate statements" ->
   # statement does not evaluate to a value, so we check for undefined.
   esl """
        (macro evalThis (lambda (input)
-                    (= obj ((. this evaluate) input))
+                    (= obj ((. this :evaluate) input))
                     (if (=== obj undefined)
-                        (return ((. this atom) "yep"))
-                        (return ((. this atom) "nope")))))
+                        (return ((. this :atom) "yep"))
+                        (return ((. this :atom) "nope")))))
        (evalThis (if 1 (block) (block)))
        """
     ..`@equals` "yep;"
@@ -702,8 +702,8 @@ test "quasiquote can contain nested lists" ->
        (lambda ()
         ; Convert arguments into array
         (var args
-             ((. this list apply) null ((. Array prototype slice call) arguments 0)))
-        (var total ((. this atom) ((. (. args values length) toString))))
+             ((. this :list :apply) null ((. Array :prototype :slice :call) arguments 0)))
+        (var total ((. this :atom) ((. (. args :values :length) :toString))))
         (return `(/ (+ ,@args) ,total))))
        (mean 1 2 3)
       '''
@@ -718,20 +718,118 @@ test "array macro can be empty" ->
     ..`@equals` "[];"
 
 test "object macro produces object expression" ->
-  esl "(object a 1 b 2)"
+  esl "(object (:a 1) (:b 2))"
     ..`@equals` "({\n    a: 1,\n    b: 2\n});"
 
 test "object macro can be passed strings as keys too" ->
-  esl '(object "a" 1 "b" 2)'
+  esl '(object ("a" 1) ("b" 2))'
     ..`@equals` "({\n    'a': 1,\n    'b': 2\n});"
 
 test "object macro's value parts can be expressions" ->
-  esl '(object "a" (+ 1 2) "b" (f x))'
+  esl '(object ("a" (+ 1 2)) ("b" (f x)))'
     ..`@equals` "({\n    'a': 1 + 2,\n    'b': f(x)\n});"
-# dynamic *keys* would be ES6
+
+test "object macro's parts can be ES6 shorthands" ->
+  esl '(object (:a) (:b))'
+    ..`@equals` "({\n    a,\n    b\n});"
+
+test "object macro's key parts can be computed ES6 values" ->
+  esl '(object (a (+ 1 2)) (b (f x)))'
+    ..`@equals` "({\n    [a]: 1 + 2,\n    [b]: f(x)\n});"
+
+test "object macro can create getters" ->
+  esl '(object (get :a () (return 1)))'
+    ..`@equals` '({\n    get a() {\n        return 1;\n    }\n});'
+
+test "object macro can create setters" ->
+  esl '(object (set :a (x) (return 1)))'
+    ..`@equals` '({\n    set a(x) {\n        return 1;\n    }\n});'
+
+test "object macro can create computed getters and setters" ->
+  esl '(object (get a ()) (set a (x)))'
+    ..`@equals` '''
+    ({
+        get [a]() {
+        },
+        set [a](x) {
+        }
+    });
+    '''
+
+test "object macro's parts can be ES6 methods" ->
+  esl '''
+      (object
+        (:a () (return 1))
+        (:b (x) (return (+ x 1)))
+        (c (x y) (return (+ x y 1))))
+      '''
+    ..`@equals` """
+      ({
+          a() {
+              return 1;
+          },
+          b(x) {
+              return x + 1;
+          },
+          [c](x, y) {
+              return x + (y + 1);
+          }
+      });
+      """
+
+test "object macro compiles complex ES6 object" ->
+  esl '''
+      (object
+        (:prop)
+        (:_foo 1)
+        ((. Symbol :toStringTag) "Foo")
+
+        (get :foo ()
+          (return (. this :_foo)))
+
+        (set :foo (value)
+          (= (. this :_foo) value))
+
+        (get (. syms :Sym) ()
+          (return ((. wm :get) this)))
+
+        (set (. syms :Sym) (value)
+          ((. wm :set) this value))
+
+        (:printFoo ()
+          ((. console :log) (. this :foo)))
+
+        (:concatFoo (value)
+          (return (+ (. this :foo) value))))
+      '''
+    ..`@equals` '''
+    ({
+        prop,
+        _foo: 1,
+        [Symbol.toStringTag]: 'Foo',
+        get foo() {
+            return this._foo;
+        },
+        set foo(value) {
+            this._foo = value;
+        },
+        get [syms.Sym]() {
+            return wm.get(this);
+        },
+        set [syms.Sym](value) {
+            wm.set(this, value);
+        },
+        printFoo() {
+            console.log(this.foo);
+        },
+        concatFoo(value) {
+            return this.foo + value;
+        }
+    });
+    '''
 
 test "macro producing an object literal" ->
-  esl "(macro obj (lambda () (return '(object a 1))))
+  esl "(macro obj (lambda () (return '(object (:a 1)))))
        (obj)"
     ..`@equals` "({ a: 1 });"
 
@@ -742,28 +840,32 @@ test "macro producing a function" ->
     ..`@equals` "(function (x) {\n    return x + 3;\n});"
 
 test "property access (dotting) chains identifiers" ->
-  esl "(. a b c)"
+  esl "(. a :b :c)"
     ..`@equals` "a.b.c;"
+
+test "property access (dotting) chains computed identifiers" ->
+  esl "(. a b c)"
+    ..`@equals` "a[b][c];"
 
 test "property access (dotting) chains literals" ->
   esl "(. a 1 2)"
     ..`@equals` "a[1][2];"
 
 test "property access (dotting) can be nested" ->
-  esl "(. a (. a (. b name)))"
+  esl "(. a (. a (. b :name)))"
     ..`@equals` "a[a[b.name]];"
 
 test "property access (dotting) chains mixed literals and identifiers" ->
-  esl "(. a b 2 a)"
+  esl "(. a :b 2 :a)"
     ..`@equals` "a.b[2].a;"
+
+test "property access (dotting) chains mixed literals and values" ->
+  esl "(. a b 2 :a)"
+    ..`@equals` "a[b][2].a;"
 
 test "property access (dotting) treats strings as literals, not identifiers" ->
   esl "(. a \"hi\")"
     ..`@equals` "a['hi'];"
-
-test "computed member expression (\"square brackets\")" ->
-  esl "(get a b 5)"
-    ..`@equals` "a[b][5];"
 
 test "regex literal" ->
   esl '(regex ".*")'
@@ -788,7 +890,7 @@ test "regex can be given atoms with escaped spaces and slashes" ->
 test "macro deliberately breaking hygiene for function argument anaphora" ->
   esl "(macro : (lambda (body)
        (return `(lambda (it) ,body))))
-        (: (return (. it x)))"
+        (: (return (. it :x)))"
     ..`@equals` "(function (it) {\n    return it.x;\n});"
 
 test "macro given nothing produces no output" ->
@@ -802,12 +904,12 @@ test "when returned from an IIFE, macros can share state" ->
       (macro
        ((lambda () (var x 0)
         (return (object
-                 plusPrev  (lambda (n)
-                                   (+= x ((. this evaluate) n))
-                                   (return ((. this atom) ((. x toString)))))
-                 timesPrev (lambda (n)
-                                   (*= x ((. this evaluate) n))
-                                   (return ((. this atom) ((. x toString))))))))))
+                 (:plusPrev  (lambda (n)
+                                   (+= x ((. this :evaluate) n))
+                                   (return ((. this :atom) ((. x :toString))))))
+                 (:timesPrev (lambda (n)
+                                   (*= x ((. this :evaluate) n))
+                                   (return ((. this :atom) ((. x :toString)))))))))))
       (plusPrev 2) (timesPrev 2)
        """
    ..`@equals` "2;\n4;"
@@ -823,17 +925,17 @@ test "macro constructor loading from IIFE can load nothing" ->
    ..`@equals` ""
 
 test "macro can return multiple statements with `multi`" ->
-  esl "(macro declareTwo (lambda () (return ((. this multi) '(var x 0) '(var y 1)))))
+  esl "(macro declareTwo (lambda () (return ((. this :multi) '(var x 0) '(var y 1)))))
        (declareTwo)"
    ..`@equals` "var x = 0;\nvar y = 1;"
 
 test "macro can check argument type and get its value" ->
   esl '''
       (macro stringy (lambda (x)
-       (if (== (. x type) "atom")
-        (return ((. this string) (+ "atom:" (. x value))))
+       (if (== (. x :type) "atom")
+        (return ((. this :string) (+ "atom:" (. x :value))))
         (block
-         (if (== (. x type) "string")
+         (if (== (. x :type) "string")
           (return x)
           (return "An unexpected development!"))))))
       (stringy a)
@@ -846,7 +948,7 @@ test "macro returning atom with empty or null name fails" ->
   <[ "" null undefined ]>.for-each ->
     self.throws do
       -> esl """
-          (macro mac (lambda () (return ((. this atom) #it))))
+          (macro mac (lambda () (return ((. this :atom) #it))))
           (mac)
           """
       Error
@@ -868,7 +970,7 @@ test "macros can be required relative to root directory" ->
   main-path = path.join dir-name, main-basename
   main-fd = fs.open-sync main-path, \a+
   fs.write-sync main-fd, """
-    (macro (object x (require "./#module-basename")))
+    (macro (object (:x (require "./#module-basename"))))
     (x)
     """
 
@@ -905,7 +1007,7 @@ test "macros can be required from node_modules relative to root directory" ->
   # Attempt to require it and use it as a macro
 
   esl """
-    (macro (object x (require "#module-name")))
+    (macro (object (:x (require "#module-name"))))
     (x)
     """
     ..`@equals` ""
@@ -927,7 +1029,7 @@ test "macros required from separate modules can access complation env" ->
     """
 
   code = esl """
-    (macro (object x (require "#name")))
+    (macro (object (:x (require "#name"))))
     (x)
     """
 
@@ -972,7 +1074,7 @@ test "macro-generating macro" -> # yes srsly
 test "macro generating macro and macro call" -> # yes srsly squared
   esl '''
     (macro define-and-call (lambda (x)
-      (return ((. this multi) `(macro what (lambda () (return `(hello))))
+      (return ((. this :multi) `(macro what (lambda () (return `(hello))))
                               `(what)))))
     (define-and-call)
     '''
@@ -1011,7 +1113,7 @@ test "invalid AST returned by macro throws error" ->
 test "macro multi-returning with bad values throws descriptive error" ->
   try
     esl '''
-      (macro breaking (lambda () (return ((. this multi) null))))
+      (macro breaking (lambda () (return ((. this :multi) null))))
       (breaking)
       '''
   catch e
@@ -1033,8 +1135,8 @@ test "macro return intermediates may be invalid if fixed by later macro" ->
 test "macro can return estree object" ->
   esl '''
     (macro identifier (lambda ()
-      (return (object "type" "Identifier"
-                      "name" "x"))))
+      (return (object ("type" "Identifier")
+                      ("name" "x")))))
     (identifier)
     '''
       ..`@equals` "x;"
@@ -1042,11 +1144,11 @@ test "macro can return estree object" ->
 test "macro can multi-return estree objects" ->
   esl '''
     (macro identifiers (lambda ()
-      (return ((. this multi)
-               (object "type" "Identifier"
-                       "name" "x")
-               (object "type" "Identifier"
-                       "name" "y")))))
+      (return ((. this :multi)
+               (object ("type" "Identifier")
+                       ("name" "x"))
+               (object ("type" "Identifier")
+                       ("name" "y"))))))
     (identifiers)
     '''
       ..`@equals` "x;\ny;"
@@ -1054,9 +1156,9 @@ test "macro can multi-return estree objects" ->
 test "macro can multi-return a combination of estree and sexprs" ->
   esl '''
     (macro identifiers (lambda ()
-      (return ((. this multi)
-               (object "type" "Identifier"
-                       "name" "x")
+      (return ((. this :multi)
+               (object ("type" "Identifier")
+                       ("name" "x"))
                'x))))
     (identifiers)
     '''
@@ -1065,11 +1167,11 @@ test "macro can multi-return a combination of estree and sexprs" ->
 test "macro can compile and return parameter as estree" ->
   esl '''
     (macro that (lambda (x)
-      (return ((. this compile) x))))
+      (return ((. this :compile) x))))
     (that 3)
     (that "hi")
     (that (c))
-    (that (object a b))
+    (that (object (:a b)))
     '''
       ..`@equals` "3;\n'hi';\nc();\n({ a: b });"
 


### PR DESCRIPTION
@anko 

Fixes #13, #23, #22.

This intentionally reserves generators, because those haven't been
implemented in functions yet. It will be easy to add when they are
implemented elsewhere, though.

It also is based on @tabatkins' [idea](https://github.com/anko/eslisp/issues/13#issue-108024207) of using `:keyword` to refer to symbols rather than simple atoms.

Note that this can change depending on the outcome of anko/sexpr-plus#3, as it would allow for a better integration into the syntax level (and also to help decouple the standard library a little). That modification would also, IMHO, be a little less fragile, and it's almost trivial to convert my patch to use that version if implemented. Matter of fact, that would actually simplify it, as I'm checking just types rather than a type _and_ the first character.

And, well, a single quote looks better. :smile: But as it stands, this is a WIP until anko/sexpr-plus#3 is addressed
