### PR TITLE
Fix for loading macros from relative paths when run within a Node REPL

### DIFF
--- a/src/built-in-macros.ls
+++ b/src/built-in-macros.ls
@@ -412,12 +412,16 @@ contents =
       # are searched.
 
       {main} = require
-      dirname = "."
-      main
-        ..paths = main.constructor._node-module-paths process.cwd!
-        ..filename = dirname
+      if main
+        dirname = "."
+        main
+          ..paths = main.constructor._node-module-paths process.cwd!
+          ..filename = dirname
 
-      root-require = main.require.bind main
+        root-require = main.require.bind main
+      else
+        # require.main is undefined within Node REPL, so use global require.
+        root-require = require
 
       let require = root-require
         eval "(#{env.compile-to-js es-ast})"


### PR DESCRIPTION
I've been interactively testing my interoperation of eslisp with bog standard JS within a Node REPL.

However, macros can not be defined within this environment due to the assumption that `require.main` will always be valid made at https://github.com/anko/eslisp/blob/master/src/built-in-macros.ls#L404-L423 (_"hack around require makes loading macros from relative paths work"_).

`require.main` is `undefined` when eslisp (or any module) is imported interactively into the Node REPL. Evaluating any macro within eslisp within the REPL environment results in the following exception:

```
TypeError: Error evaluating macro `macro` (called at line 1, column 0): Cannot read property 'constructor' of undefined
    at compileAsMacro (/Users/anthony/src/eslisp/lib/built-in-macros.js:574:22)
```

The change in this PR calls `env.compile-to-js` with Node's global `require` when `require.main` is `undefined`, allowing macros to be used within the REPL, and with relative imports based at the folder where the Node REPL was executed.